### PR TITLE
Nodes Recovery: add infrastructure info to DB

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1187,6 +1187,11 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             throw new RuntimeException("Cannot create node source " + data.getName(), e);
         }
 
+        // Infrastructure has been configured and linked to the node source, so we can now persist the runtime
+        // variables of the infrastructure for the first time (they have been initialized during the creation of the
+        // infrastructure, in its configuration.
+        im.persistInfrastructureVariables();
+
         // Adding access to the core for node source and policy.
         // In order to do it node source and policy active objects are added to the clients list.
         // They will be removed from this list when node source is unregistered.

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.db;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -33,12 +34,12 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import javax.security.auth.Subject;
 
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.hibernate.type.SerializableToBlobType;
 import org.ow2.proactive.resourcemanager.authentication.Client;
+import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 
 
 @Entity
@@ -60,6 +61,11 @@ public class NodeSourceData implements Serializable {
     private Object[] policyParameters;
 
     private Client provider;
+
+    /**
+     * name of the variable --> value of the variable
+     */
+    private Map<String, Object> infrastructureVariables;
 
     public NodeSourceData() {
     }
@@ -132,4 +138,15 @@ public class NodeSourceData implements Serializable {
     public void setProvider(Client provider) {
         this.provider = provider;
     }
+
+    @Column(length = Integer.MAX_VALUE)
+    @Type(type = "org.hibernate.type.SerializableToBlobType", parameters = @Parameter(name = SerializableToBlobType.CLASS_NAME, value = "java.lang.Object"))
+    public Map<String, Object> getInfrastructureVariables() {
+        return infrastructureVariables;
+    }
+
+    public void setInfrastructureVariables(Map<String, Object> infrastructureVariables) {
+        this.infrastructureVariables = infrastructureVariables;
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
@@ -298,14 +298,34 @@ public class RMDBManager {
     }
 
     public NodeSourceData getNodeSource(final String sourceName) {
-        return executeReadTransaction(new SessionWork<NodeSourceData>() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public NodeSourceData doInTransaction(Session session) {
-                Query query = session.getNamedQuery("getNodeSourceDataByName").setParameter("name", sourceName);
-                return (NodeSourceData) query.uniqueResult();
-            }
-        });
+        try {
+            return executeReadTransaction(new SessionWork<NodeSourceData>() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public NodeSourceData doInTransaction(Session session) {
+                    Query query = session.getNamedQuery("getNodeSourceDataByName").setParameter("name", sourceName);
+                    return (NodeSourceData) query.uniqueResult();
+                }
+            });
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Exception occured while getting a node source from name '" + sourceName + "'");
+        }
+    }
+
+    public boolean updateNodeSource(final NodeSourceData nodeSourceData) {
+        try {
+            return executeReadWriteTransaction(new SessionWork<Boolean>() {
+                @Override
+                public Boolean doInTransaction(Session session) {
+                    logger.info("Updating a node source " + nodeSourceData.getName() + " in database");
+                    session.update(nodeSourceData);
+                    return true;
+                }
+            });
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Exception occured while updating a node source '" + nodeSourceData.getName() +
+                                       "'");
+        }
     }
 
     public void removeNodeSource(final String sourceName) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/DefaultInfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/DefaultInfrastructureManager.java
@@ -46,7 +46,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
     protected static Logger logger = Logger.getLogger(DefaultInfrastructureManager.class);
 
     /** registered nodes number */
-    protected int nodesCount = 0;
+    private static final String NODES_COUNT_KEY = "nodesCount";
 
     /**
      * Proactive default constructor.
@@ -99,7 +99,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
                     }
                 });
             }
-            nodesCount--;
+            decrementNodesCount();
         } catch (Exception e) {
             throw new RMException(e);
         }
@@ -149,7 +149,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
      */
     @Override
     public void notifyAcquiredNode(Node node) throws RMException {
-        nodesCount++;
+        incrementNodesCount();
     }
 
     /**
@@ -166,6 +166,35 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
      */
     @Override
     public void shutDown() {
+    }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(NODES_COUNT_KEY, 0);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private void incrementNodesCount() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(NODES_COUNT_KEY) + 1;
+                runtimeVariables.put(NODES_COUNT_KEY, updated);
+                return null;
+            }
+        });
+    }
+
+    private void decrementNodesCount() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(NODES_COUNT_KEY) - 1;
+                runtimeVariables.put(NODES_COUNT_KEY, updated);
+                return null;
+            }
+        });
     }
 
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
@@ -32,12 +32,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.exception.RMException;
@@ -69,22 +67,25 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
     /**
      * map of free hosts with the number of nodes to deploy on each host
      */
-    private ConcurrentHashMap<InetAddress, Integer> freeHosts = new ConcurrentHashMap<>();
+    private static final String FREE_HOSTS_KEY = "freeHosts";
 
     /**
      * The set of nodes for which one the registerAcquiredNode has been run.
      */
-    private Hashtable<String, InetAddress> registeredNodes = new Hashtable<>();
+    private static final String REGISTERED_NODES_KEY = "registeredNodes";
 
     /**
      * Nodes previously removed
      */
-    final ConcurrentHashMap<InetAddress, AtomicInteger> removedNodes = new ConcurrentHashMap<>();
+    private static final String REMOVED_NODES_KEY = "removedNodes";
 
     /**
      * To notify the control loop of the deploying node timeout
      */
-    protected ConcurrentHashMap<String, Boolean> pnTimeout = new ConcurrentHashMap<>();
+    private static final String PN_TIMEOUT_KEY = "pnTimeout";
+
+    protected HostsFileBasedInfrastructureManager() {
+    }
 
     /**
      * Acquire one node per available host
@@ -92,7 +93,7 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
     @Override
     public void acquireAllNodes() {
 
-        while (freeHosts.size() > 0) {
+        while (getFreeHostsSize() > 0) {
             acquireNode();
         }
 
@@ -106,16 +107,17 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
         final InetAddress tmpHost;
         final int nbNodes;
 
-        if (freeHosts.size() == 0) {
+        if (getFreeHostsSize() == 0) {
             logger.info("Attempting to acquire nodes while all hosts are already deployed.");
             return;
         }
-        Iterator<Map.Entry<InetAddress, Integer>> iterator = freeHosts.entrySet().iterator();
+        Iterator<Map.Entry<InetAddress, Integer>> iterator = getFreeHostsEntrySetIterator();
         final Map.Entry<InetAddress, Integer> tmpEntry = iterator.next();
         iterator.remove();
         tmpHost = tmpEntry.getKey();
         nbNodes = tmpEntry.getValue();
-        logger.info("Acquiring a new node. #freeHosts:" + freeHosts.size() + " #registered: " + registeredNodes.size());
+        logger.info("Acquiring a new node. #freeHosts:" + getFreeHostsSize() + " #registered: " +
+                    getRegisteredNodesSize());
 
         this.nodeSource.executeInParallel(new Runnable() {
             public void run() {
@@ -123,14 +125,14 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
                     startNodeImplWithRetries(tmpHost, nbNodes, maxDeploymentFailure);
 
                     //node acquisition went well for host so we update the threshold
-                    logger.debug("Node acquisition ended. #freeHosts:" + freeHosts.size() + " #registered: " +
-                                 registeredNodes.size());
+                    logger.debug("Node acquisition ended. #freeHosts:" + getFreeHostsSize() + " #registered: " +
+                                 getRegisteredNodesSize());
 
                 } catch (Exception e) {
 
                     String description = "Could not acquire node on host " + tmpHost +
                                          ". NS's state refreshed regarding last checked exception: #freeHosts:" +
-                                         freeHosts.size() + " #registered: " + registeredNodes.size();
+                                         getFreeHostsSize() + " #registered: " + getRegisteredNodesSize();
                     logger.error(description, e);
                     return;
                 }
@@ -224,7 +226,20 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
             try {
                 InetAddress addr = InetAddress.getByName(host);
 
-                this.freeHosts.putIfAbsent(addr, num);
+                // do not use the setRuntimeVariable method here because we cannot persist the variable yet: we need
+                // the configuration to be over for that
+                writeLock.lock();
+                try {
+                    Integer retrieved = getFreeHosts().get(addr);
+                    if (retrieved == null) {
+                        getFreeHosts().put(addr, num);
+                    }
+                } catch (RuntimeException e) {
+                    logger.error("Exception while manipulating free nodes data structure: " + e.getMessage());
+                    throw e;
+                } finally {
+                    writeLock.unlock();
+                }
 
             } catch (UnknownHostException ex) {
                 throw new RuntimeException("Unknown host: " + host, ex);
@@ -239,7 +254,7 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
      */
     @Override
     protected void notifyDeployingNodeLost(String pnURL) {
-        this.pnTimeout.put(pnURL, new Boolean(true));
+        putPnTimeout(pnURL, Boolean.TRUE);
     }
 
     /**
@@ -248,10 +263,10 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
     @Override
     protected void notifyAcquiredNode(Node node) throws RMException {
         String nodeName = node.getNodeInformation().getName();
-        this.registeredNodes.put(nodeName, node.getVMInformation().getInetAddress());
+        putRegisteredNodes(nodeName, node.getVMInformation().getInetAddress());
         if (logger.isDebugEnabled()) {
-            logger.debug("New expected node registered: #freeHosts:" + freeHosts.size() + " #registered: " +
-                         registeredNodes.size());
+            logger.debug("New expected node registered: #freeHosts:" + getFreeHostsSize() + " #registered: " +
+                         getRegisteredNodesSize());
         }
     }
 
@@ -262,23 +277,23 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
     public void removeNode(Node node) {
         InetAddress host = null;
         String nodeName = node.getNodeInformation().getName();
-        if ((host = registeredNodes.remove(nodeName)) != null) {
+        if ((host = removeRegisteredNodes(nodeName)) != null) {
             logger.debug("Removing node " + node.getNodeInformation().getURL() + " from " +
                          this.getClass().getSimpleName());
             // remember the node removed
-            removedNodes.putIfAbsent(host, new AtomicInteger(0));
-            removedNodes.get(host).incrementAndGet();
-            if (!registeredNodes.containsValue(host)) {
+            putIfAbsentRemovedNodes(host, 0);
+            incrementRemovedNodes(host);
+            if (!containsValueRegisteredNodes(host)) {
                 try {
                     this.killNodeImpl(node, host);
                 } catch (Exception e) {
                     logger.trace("An exception occurred during node removal", e);
                 }
                 // in case all nodes relative to this host were removed kill the JVM
-                freeHosts.putIfAbsent(host, removedNodes.remove(host).intValue());
+                putIfAbsentFreeHosts(host, removeRemovedNodes(host));
             }
-            logger.info("Node " + nodeName + " removed. #freeHosts:" + freeHosts.size() + " #registered nodes: " +
-                        registeredNodes.size());
+            logger.info("Node " + nodeName + " removed. #freeHosts:" + getFreeHostsSize() + " #registered nodes: " +
+                        getRegisteredNodesSize());
 
         } else {
             logger.error("Node " + nodeName + " is not known as a node belonging to this infrastructure manager");
@@ -293,17 +308,17 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
         // like most of the other methods of this class...
         // See https://github.com/ow2-proactive/scheduling/issues/2811
 
-        AtomicInteger nbNodesRemoved = removedNodes.get(host);
+        Integer nbNodesRemoved = getRemovedNode(host);
 
         if (nbNodesRemoved != null) {
-            nbNodesRemoved.decrementAndGet();
-            registeredNodes.put(node.getNodeInformation().getName(), host);
+            decrementRemovedNodes(host);
+            putRegisteredNodes(node.getNodeInformation().getName(), host);
         }
     }
 
     protected boolean anyTimedOut(List<String> nodesUrl) {
         for (String nodeUrl : nodesUrl) {
-            if (pnTimeout.get(nodeUrl)) {
+            if (getPnTimeout(nodeUrl)) {
                 return true;
             }
         }
@@ -312,13 +327,13 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
 
     protected void removeTimeouts(List<String> nodesUrl) {
         for (String nodeUrl : nodesUrl) {
-            pnTimeout.remove(nodeUrl);
+            removePnTimeout(nodeUrl);
         }
     }
 
     protected void addTimeouts(List<String> nodesUrl) {
         for (String pnUrl : nodesUrl) {
-            this.pnTimeout.put(pnUrl, false);
+            putPnTimeout(pnUrl, false);
         }
     }
 
@@ -373,6 +388,14 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
 
     }
 
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(FREE_HOSTS_KEY, new HashMap<InetAddress, Integer>());
+        runtimeVariables.put(REGISTERED_NODES_KEY, new HashMap<String, InetAddress>());
+        runtimeVariables.put(REMOVED_NODES_KEY, new HashMap<InetAddress, Integer>());
+        runtimeVariables.put(PN_TIMEOUT_KEY, new HashMap<String, Boolean>());
+    }
+
     /**
      * Launch the node on the host passed as parameter
      * @param host The host on which one the node will be started
@@ -390,4 +413,173 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
      * @throws RMException if a problem occurred while removing
      */
     protected abstract void killNodeImpl(Node node, InetAddress host) throws RMException;
+
+    // Below are wrapper methods around the runtime variables map
+
+    private Map<InetAddress, Integer> getFreeHosts() {
+        return (Map<InetAddress, Integer>) runtimeVariables.get(FREE_HOSTS_KEY);
+    }
+
+    private int getFreeHostsSize() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return getFreeHosts().size();
+            }
+        });
+    }
+
+    private void putIfAbsentFreeHosts(final InetAddress inetAddress, final Integer value) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                Integer retrieved = getFreeHosts().get(inetAddress);
+                if (retrieved == null) {
+                    getFreeHosts().put(inetAddress, value);
+                }
+                return null;
+            }
+        });
+    }
+
+    private Iterator<Map.Entry<InetAddress, Integer>> getFreeHostsEntrySetIterator() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Iterator<Map.Entry<InetAddress, Integer>>>() {
+            @Override
+            public Iterator<Map.Entry<InetAddress, Integer>> handle() {
+                return getFreeHosts().entrySet().iterator();
+            }
+        });
+    }
+
+    private Map<String, InetAddress> getRegisteredNodes() {
+        return (Map<String, InetAddress>) runtimeVariables.get(REGISTERED_NODES_KEY);
+    }
+
+    private int getRegisteredNodesSize() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return getRegisteredNodes().size();
+            }
+        });
+    }
+
+    private void putRegisteredNodes(final String nodeName, final InetAddress inetAddress) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getRegisteredNodes().put(nodeName, inetAddress);
+                return null;
+            }
+        });
+    }
+
+    private InetAddress removeRegisteredNodes(final String nodeName) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<InetAddress>() {
+            @Override
+            public InetAddress handle() {
+                return getRegisteredNodes().remove(nodeName);
+            }
+        });
+    }
+
+    private boolean containsValueRegisteredNodes(final InetAddress inetAddress) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getRegisteredNodes().containsValue(inetAddress);
+            }
+        });
+    }
+
+    private Map<InetAddress, Integer> getRemovedNodes() {
+        return (Map<InetAddress, Integer>) runtimeVariables.get(REMOVED_NODES_KEY);
+    }
+
+    private int getRemovedNode(final InetAddress inetAddress) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return getRemovedNodes().get(inetAddress);
+            }
+        });
+    }
+
+    private void putIfAbsentRemovedNodes(final InetAddress inetAddress, final int value) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                Integer retrieved = getRemovedNodes().get(inetAddress);
+                if (retrieved == null) {
+                    getRemovedNodes().put(inetAddress, value);
+                }
+                return null;
+            }
+        });
+    }
+
+    private void incrementRemovedNodes(final InetAddress inetAddress) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = getRemovedNodes().get(inetAddress) + 1;
+                getRemovedNodes().put(inetAddress, updated);
+                return null;
+            }
+        });
+    }
+
+    private void decrementRemovedNodes(final InetAddress inetAddress) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = getRemovedNodes().get(inetAddress) - 1;
+                getRemovedNodes().put(inetAddress, updated);
+                return null;
+            }
+        });
+    }
+
+    private int removeRemovedNodes(final InetAddress inetAddress) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return getRemovedNodes().remove(inetAddress);
+            }
+        });
+    }
+
+    private Map<String, Boolean> getPnTimeoutMap() {
+        return (Map<String, Boolean>) runtimeVariables.get(PN_TIMEOUT_KEY);
+    }
+
+    private Boolean getPnTimeout(final String key) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getPnTimeoutMap().get(key);
+            }
+        });
+    }
+
+    private void putPnTimeout(final String key, final Boolean value) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getPnTimeoutMap().put(key, value);
+                return null;
+            }
+        });
+    }
+
+    private void removePnTimeout(final String key) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getPnTimeoutMap().remove(key);
+                return null;
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
@@ -30,13 +30,14 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
@@ -45,6 +46,8 @@ import org.ow2.proactive.resourcemanager.authentication.Client;
 import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.event.RMEventType;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeEvent;
+import org.ow2.proactive.resourcemanager.db.NodeSourceData;
+import org.ow2.proactive.resourcemanager.db.RMDBManager;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 import org.ow2.proactive.resourcemanager.rmnode.RMDeployingNode;
@@ -83,31 +86,88 @@ public abstract class InfrastructureManager implements Serializable {
     /** manager's node source */
     protected NodeSource nodeSource;
 
-    /** deploying nodes list */
-    private final Map<String, RMDeployingNode> deployingNodes = new ConcurrentHashMap<>();
+    /** key to retrieve the deploying nodes list: Map<String, RMDeployingNode> */
+    private static final String DEPLOYING_NODES_KEY = "infrastructureManagerDeployingNodes";
 
-    private final Map<String, RMDeployingNode> lostNodes = new ConcurrentHashMap<>();
+    /** key to retrieve the lost nodes list: Map<String, RMDeployingNode> */
+    private static final String LOST_NODES_KEY = "infrastructureManagerLostNodes";
 
     /**
-     * node list, miror of nodesource.getAliveNodes(), to implement random
+     * key to retrieve node list, miror of nodesource.getAliveNodes(), to implement random
      * access
      */
-    private Hashtable<String, Node> acquiredNodes = new Hashtable<>();
+    private static final String ACQUIRED_NODES_KEY = "infrastructureManagerAcquiredNodes";
 
-    private final ReentrantLock nodeAcquisitionLock = new ReentrantLock();
+    private static final String USING_DEPLOYING_NODES_KEY = "usingDeployingNodes";
 
-    // shared fields, needs to be volatile not to cache it
-    private volatile boolean usingDeployingNodes = false;
-
-    // shutdown marker
-    private volatile boolean shutdown = false;
+    // key to retrieve the shutdown marker
+    private static final String SHUTDOWN_FLAG_KEY = "infrastructureManagerShutdown";
 
     // used to timeout the nodes
     private transient Timer timeouter = null;
 
-    protected String rmUrl;
+    private static final String RM_URL_KEY = "infrastructureManagerRmUrl";
+
+    /**
+     * Store information about the running infrastructure. The map holds the name of monitored information and its
+     * value. The variables stored in this map should allow the full recovery of an infrastructure state.
+     * All accesses to this map must be synchronized.
+     */
+    protected Map<String, Object> runtimeVariables = new HashMap<>();
+
+    private ReadWriteLock reentrantLock = new ReentrantReadWriteLock();
+
+    /** Use this lock to wrap a read access to runtime variables */
+    protected Lock readLock = reentrantLock.readLock();
+
+    /** Use this lock to wrap a write access to runtime variables */
+    protected Lock writeLock = reentrantLock.writeLock();
+
+    /**
+     * Database manager, used to persist the runtime variables.
+     */
+    private RMDBManager dbManager;
 
     public InfrastructureManager() {
+    }
+
+    /**
+     * Acquire the read lock and call the handle method of the handler given in parameter.
+     * @return the value returned by the handle method
+     */
+    protected <T> T getRuntimeVariable(RuntimeVariablesHandler<T> t) {
+        T variable = null;
+        readLock.lock();
+        try {
+            variable = t.handle();
+        } catch (RuntimeException e) {
+            logger.error("Exception while getting runtime variable: " + e.getMessage());
+            throw e;
+        } finally {
+            readLock.unlock();
+        }
+        return variable;
+    }
+
+    /**
+     * Acquire the write lock, and then:
+     * 1) call the handle method of the handler given in parameter
+     * 2) call the method that persist in database the runtime variables.
+     * @return the return value of the handle method
+     */
+    protected <T> T setRuntimeVariable(RuntimeVariablesHandler<T> t) {
+        T variable = null;
+        writeLock.lock();
+        try {
+            variable = t.handle();
+            persistInfrastructureVariables();
+        } catch (RuntimeException e) {
+            logger.error("Exception while setting runtime variable: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
+        }
+        return variable;
     }
 
     /**
@@ -119,7 +179,18 @@ public abstract class InfrastructureManager implements Serializable {
      */
     public void setNodeSource(NodeSource nodeSource) {
         this.nodeSource = nodeSource;
-        this.rmUrl = nodeSource.getRegistrationURL();
+        // we do not set this variable using the setRuntimeVariable method because we do not want to persist
+        // at this time: the node source has not been persisted yet.
+        writeLock.lock();
+        try {
+            runtimeVariables.put(RM_URL_KEY, nodeSource.getRegistrationURL());
+        } catch (RuntimeException e) {
+            logger.error("Exception while putting RM URL in runtime variables: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
+        }
+
     }
 
     /**
@@ -129,25 +200,28 @@ public abstract class InfrastructureManager implements Serializable {
      */
     public ArrayList<RMDeployingNode> getDeployingNodes() {
         ArrayList<RMDeployingNode> result;
-        synchronized (deployingNodes) {
-            Collection<RMDeployingNode> rmDeployingNodes = this.deployingNodes.values();
-            Collection<RMDeployingNode> rmLostNodes = this.lostNodes.values();
+        readLock.lock();
+        try {
+            Collection<RMDeployingNode> rmDeployingNodes = valuesDeployingNodes();
+            Collection<RMDeployingNode> rmLostNodes = valuesLostNodes();
             result = new ArrayList<>(rmDeployingNodes.size() + rmLostNodes.size());
             result.addAll(rmDeployingNodes);
             result.addAll(rmLostNodes);
+        } catch (RuntimeException e) {
+            logger.error("Exception while getting deploying and lost nodes: " + e.getMessage());
+            throw e;
+        } finally {
+            readLock.unlock();
         }
         return result;
     }
 
     public RMDeployingNode getDeployingNode(String nodeUrl) {
-        RMDeployingNode deployingNode;
 
-        synchronized (deployingNodes) {
-            deployingNode = deployingNodes.get(nodeUrl);
-        }
+        RMDeployingNode deployingNode = getDeployingNodeFromRuntimeVariables(nodeUrl);
 
         if (deployingNode == null) {
-            return lostNodes.get(nodeUrl);
+            return getLostNodeFromRuntimeVariables(nodeUrl);
         }
 
         return deployingNode;
@@ -163,13 +237,21 @@ public abstract class InfrastructureManager implements Serializable {
     public final boolean internalRemoveDeployingNode(String pnUrl) {
         RMDeployingNode pn = null;
         boolean isLost = false;
-        synchronized (deployingNodes) {
-            pn = this.deployingNodes.remove(pnUrl);
+
+        writeLock.lock();
+        try {
+            pn = removeDeployingNode(pnUrl);
             if (pn == null) {
-                pn = this.lostNodes.remove(pnUrl);
+                pn = removeLostNode(pnUrl);
                 isLost = true;
             }
+        } catch (RuntimeException e) {
+            logger.error("Exception while removing deploying node: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
+
         // if such a deploying or lost node exists
         if (pn != null) {
             String url = pn.getNodeURL();
@@ -198,7 +280,7 @@ public abstract class InfrastructureManager implements Serializable {
      */
     public final void internalRemoveNode(Node node) throws RMException {
         try {
-            this.acquiredNodes.remove(node.getNodeInformation().getName());
+            removeAcquiredNode(node.getNodeInformation().getName());
         } catch (Exception e) {
             logger.warn("Exception occurred while removing node " + node);
         }
@@ -247,7 +329,7 @@ public abstract class InfrastructureManager implements Serializable {
         // if implementation doesn't use deploying nodes, we just execute
         // factory method and return
 
-        if (!usingDeployingNodes) {
+        if (!isUsingDeployingNode()) {
             this.notifyAcquiredNode(node);
             return null;
         }
@@ -255,8 +337,10 @@ public abstract class InfrastructureManager implements Serializable {
         RMDeployingNode pn;
         // we build the url of the associated deploying node
         String deployingNodeURL = this.buildDeployingNodeURL(node.getNodeInformation().getName());
-        synchronized (nodeAcquisitionLock) {
-            pn = this.deployingNodes.remove(deployingNodeURL);
+
+        writeLock.lock();
+        try {
+            pn = removeDeployingNode(deployingNodeURL);
             // if a deploying node with this name exists, one runs the
             // implementation callback
             if (pn != null) {
@@ -267,7 +351,7 @@ public abstract class InfrastructureManager implements Serializable {
                 this.notifyAcquiredNode(node);
                 // if everything went well with the new node, caching it
                 try {
-                    this.acquiredNodes.put(node.getNodeInformation().getName(), node);
+                    putAcquiredNode(node.getNodeInformation().getName(), node);
                 } catch (Exception e) {
                     // if an exception occurred, we don't want to discard the
                     // node registration
@@ -278,6 +362,11 @@ public abstract class InfrastructureManager implements Serializable {
                 logger.warn("Not expected node registered, discarding it: " + url);
                 throw new RMException("Not expected node registered, discarding it: " + url);
             }
+        } catch (RuntimeException e) {
+            logger.error("Exception while changing deploying node to acquired node: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
 
         return pn;
@@ -325,7 +414,17 @@ public abstract class InfrastructureManager implements Serializable {
      *             if the parameters are invalid
      */
     public final void internalConfigure(Object... parameters) {
-        this.configure(parameters);
+        writeLock.lock();
+        try {
+            internalInitializeRuntimeVariables();
+            initializeRuntimeVariables();
+            this.configure(parameters);
+        } catch (RuntimeException e) {
+            logger.error("Exception while initializing runtime variables and configuring infrastructure: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     /**
@@ -334,14 +433,14 @@ public abstract class InfrastructureManager implements Serializable {
      * implementation thanks to the method {@link #shutDown()}
      */
     public final void internalShutDown() {
-        this.shutdown = true;
+        setShutdownFlag(true);
         // first removing deploying nodes
-        for (String dnUrl : this.deployingNodes.keySet()) {
+        for (String dnUrl : keySetDeployingNodes()) {
             this.internalRemoveDeployingNode(dnUrl);
         }
         // no need to remove lost nodes, implementation is notified
         // at the timeout of the deploying node
-        this.deployingNodes.clear();
+        clearDeployingNodes();
         // delegating the call to the implementation
         this.shutDown();
 
@@ -363,6 +462,9 @@ public abstract class InfrastructureManager implements Serializable {
     /**
      * Adds information required to deploy nodes in the future. Do not initiate
      * a real nodes deployment/acquisition as it's up to the policy.
+     * The runtime variables of an infrastructure should not be explicitly persisted in this method as the link with
+     * the node source is not properly set at the time of calling this method. They will be persisted at the end of the
+     * initialization in RMCore#createNodeSource
      *
      * @param parameters
      *            of the infrastructure manager
@@ -440,6 +542,23 @@ public abstract class InfrastructureManager implements Serializable {
     protected void shutDown() {
     }
 
+    /**
+     * First fetch the {@link NodeSourceData} associated to this infrastructure, then update the information related to
+     * the infrastructure, and then update in database the {@link NodeSourceData}.
+     */
+    public void persistInfrastructureVariables() {
+        if (dbManager == null) {
+            setRmDbManager(RMDBManager.getInstance());
+        }
+        NodeSourceData nodeSource = dbManager.getNodeSource(this.nodeSource.getName());
+        nodeSource.setInfrastructureVariables(runtimeVariables);
+        dbManager.updateNodeSource(nodeSource);
+    }
+
+    protected void setRmDbManager(RMDBManager dbManager) {
+        this.dbManager = dbManager;
+    }
+
     // **********************************************************************************************\\
     // **************************************** API methods
     // *****************************************\\
@@ -477,7 +596,7 @@ public abstract class InfrastructureManager implements Serializable {
                              e);
             }
         }
-        result.setRmURL(this.rmUrl);
+        result.setRmURL(getRmUrl());
         if (this.nodeSource != null) {
             String nsName = this.nodeSource.getName();
             result.setSourceName(nsName);
@@ -515,12 +634,12 @@ public abstract class InfrastructureManager implements Serializable {
     protected final String addDeployingNode(String name, String command, String description, final long timeout) {
         checkName(name);
         checkTimeout(timeout);
-        if (shutdown) {
+        if (getShutdownFlag()) {
             throw new UnsupportedOperationException("The infrastructure manager is shuting down.");
         }
         // if the user calls this method, we use the require nodes/timeout
         // mecanism
-        usingDeployingNodes = true;
+        setUsingDeployingNodes(true);
         NodeSource nsStub = this.nodeSource.getStub();
         RMDeployingNode deployingNode = RMDeployingNodeAccessor.getDefault().newRMDeployingNode(name,
                                                                                                 nsStub,
@@ -528,7 +647,7 @@ public abstract class InfrastructureManager implements Serializable {
                                                                                                 nsStub.getAdministrator(),
                                                                                                 description);
         final String deployingNodeUrl = deployingNode.getNodeURL();
-        this.deployingNodes.put(deployingNodeUrl, deployingNode);
+        putDeployingNode(deployingNodeUrl, deployingNode);
 
         nodeSource.setDeploying(deployingNode);
         // The value for 'deployingNode' is retrieved before calling 'nodeSource.setDeploying'
@@ -570,7 +689,7 @@ public abstract class InfrastructureManager implements Serializable {
      *         managed by the IM anymore.
      */
     protected final boolean updateDeployingNodeDescription(String toUpdateURL, String newDescription) {
-        RMDeployingNode pn = this.deployingNodes.get(toUpdateURL);
+        RMDeployingNode pn = getDeployingNodeFromRuntimeVariables(toUpdateURL);
         if (pn != null) {
             NodeState previousState = pn.getState();
             RMDeployingNodeAccessor.getDefault().setDescription(pn, newDescription);
@@ -600,11 +719,17 @@ public abstract class InfrastructureManager implements Serializable {
         RMDeployingNode deployingNode;
         // we need to atomically move the node from the deploying collection to
         // the lost one.
-        synchronized (deployingNodes) {
-            deployingNode = this.deployingNodes.remove(toUpdateURL);
+        writeLock.lock();
+        try {
+            deployingNode = removeDeployingNode(toUpdateURL);
             if (deployingNode != null) {
-                this.lostNodes.put(toUpdateURL, deployingNode);
+                putLostNode(toUpdateURL, deployingNode);
             }
+        } catch (RuntimeException e) {
+            logger.error("Exception while moving a node from deploying to lost: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
 
         if (deployingNode != null) {
@@ -655,8 +780,9 @@ public abstract class InfrastructureManager implements Serializable {
      *         otherwise.
      */
     protected final boolean checkNodeIsAcquiredAndDo(String nodeName, Runnable toRunWhenOK, Runnable toRunWhenKO) {
-        synchronized (nodeAcquisitionLock) {
-            if (this.acquiredNodes.containsKey(nodeName)) {
+        writeLock.lock();
+        try {
+            if (containsKeyAcquiredNode(nodeName)) {
                 checkNodePostAction(toRunWhenOK,
                                     "An exception occurred while running implementation's code whereas the node " +
                                                  nodeName + " was found.");
@@ -667,6 +793,11 @@ public abstract class InfrastructureManager implements Serializable {
                                                  nodeName + " was not found.");
                 return false;
             }
+        } catch (RuntimeException e) {
+            logger.error("Exception while checking acquired node and doing post action: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
     }
 
@@ -728,7 +859,7 @@ public abstract class InfrastructureManager implements Serializable {
                                                "\" is forbidden");
         }
         String pnURL = this.buildDeployingNodeURL(name);
-        if (this.deployingNodes.containsKey(pnURL) || this.lostNodes.containsKey(pnURL)) {
+        if (containsKeyDeployingNode(pnURL) || containsKeyLostNode(pnURL)) {
             throw new IllegalArgumentException(RMDeployingNode.class.getSimpleName() + " with the same name (\"" +
                                                name + "\") has already been created");
         }
@@ -766,31 +897,50 @@ public abstract class InfrastructureManager implements Serializable {
      */
     public RMDeployingNode update(RMDeployingNode rmNode) {
         String nodeUrl = rmNode.getNodeURL();
-
-        if (rmNode.isLost() && lostNodes.containsKey(nodeUrl)) {
-            return lostNodes.put(nodeUrl, rmNode);
-        } else if (deployingNodes.containsKey(nodeUrl)) {
-            return deployingNodes.put(nodeUrl, rmNode);
+        RMDeployingNode previousDeployingNode;
+        if (rmNode.isLost() && containsKeyLostNode(nodeUrl)) {
+            previousDeployingNode = putLostNode(nodeUrl, rmNode);
+        } else if (containsKeyDeployingNode(nodeUrl)) {
+            previousDeployingNode = putDeployingNode(nodeUrl, rmNode);
         } else {
-            return null;
+            previousDeployingNode = null;
         }
+        return previousDeployingNode;
     }
 
     void addDeployingNode(RMDeployingNode node) {
-        deployingNodes.put(node.getNodeURL(), node);
+        putDeployingNode(node.getNodeURL(), node);
     }
 
     void addLostNode(RMDeployingNode node) {
-        lostNodes.put(node.getNodeURL(), node);
+        putLostNode(node.getNodeURL(), node);
     }
 
     Map<String, RMDeployingNode> getDeployingNodesDeployingState() {
-        return deployingNodes;
+        return getDeployingNodesMap();
     }
 
     Map<String, RMDeployingNode> getDeployingNodesLostState() {
-        return lostNodes;
+        return getLostNodesMap();
     }
+
+    private void internalInitializeRuntimeVariables() {
+        runtimeVariables.put(DEPLOYING_NODES_KEY, new HashMap<String, RMDeployingNode>());
+        runtimeVariables.put(LOST_NODES_KEY, new HashMap<String, RMDeployingNode>());
+        runtimeVariables.put(ACQUIRED_NODES_KEY, new HashMap<String, Node>());
+        runtimeVariables.put(USING_DEPLOYING_NODES_KEY, false);
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+        runtimeVariables.put(RM_URL_KEY, "");
+    }
+
+    /**
+     * This method should initialize a value in the runtime variables map for all the runtime variables that will be
+     * used in the class. It is called at initialization time of the infrastructure, just before the
+     * {@link InfrastructureManager#configure(Object...)} method.
+     *
+     * This method runs with the write lock acquired.
+     */
+    protected abstract void initializeRuntimeVariables();
 
     /**
      * Helper nested class. Used not to expose methods that should be package
@@ -852,4 +1002,221 @@ public abstract class InfrastructureManager implements Serializable {
          */
         protected abstract void setLost(RMDeployingNode pn);
     }
+
+    /**
+     * Interface that allows handling the runtime variables through a functional point of view.
+     * This allows protecting sensitive actions within one locked block.
+     *
+     * @param <T> the type of the retrieved variable if so.
+     */
+    protected interface RuntimeVariablesHandler<T> {
+
+        /**
+         * Typically, handles a sequence of actions involving the runtime variables.
+         *
+         * @return the manipulated variable.
+         */
+        T handle();
+
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private Map<String, RMDeployingNode> getDeployingNodesMap() {
+        return (Map<String, RMDeployingNode>) runtimeVariables.get(DEPLOYING_NODES_KEY);
+    }
+
+    private RMDeployingNode getDeployingNodeFromRuntimeVariables(final String nodeUrl) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getDeployingNodesMap().get(nodeUrl);
+            }
+        });
+    }
+
+    private RMDeployingNode putDeployingNode(final String nodeUrl, final RMDeployingNode deployingNode) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getDeployingNodesMap().put(nodeUrl, deployingNode);
+            }
+        });
+    }
+
+    private RMDeployingNode removeDeployingNode(final String nodeUrl) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getDeployingNodesMap().remove(nodeUrl);
+            }
+        });
+    }
+
+    private boolean containsKeyDeployingNode(final String nodeUrl) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getDeployingNodesMap().containsKey(nodeUrl);
+            }
+        });
+    }
+
+    private Collection<String> keySetDeployingNodes() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Collection<String>>() {
+            @Override
+            public Collection<String> handle() {
+                return getDeployingNodesMap().keySet();
+            }
+        });
+    }
+
+    private void clearDeployingNodes() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getDeployingNodesMap().clear();
+                return null;
+            }
+        });
+    }
+
+    private Collection<RMDeployingNode> valuesDeployingNodes() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Collection<RMDeployingNode>>() {
+            @Override
+            public Collection<RMDeployingNode> handle() {
+                return getDeployingNodesMap().values();
+            }
+        });
+    }
+
+    private Map<String, RMDeployingNode> getLostNodesMap() {
+        return (Map<String, RMDeployingNode>) runtimeVariables.get(LOST_NODES_KEY);
+    }
+
+    private RMDeployingNode getLostNodeFromRuntimeVariables(final String nodeUrl) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getLostNodesMap().get(nodeUrl);
+            }
+        });
+    }
+
+    private RMDeployingNode putLostNode(final String nodeUrl, final RMDeployingNode deployingNode) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getLostNodesMap().put(nodeUrl, deployingNode);
+            }
+        });
+    }
+
+    private RMDeployingNode removeLostNode(final String nodeUrl) {
+        return setRuntimeVariable(new RuntimeVariablesHandler<RMDeployingNode>() {
+            @Override
+            public RMDeployingNode handle() {
+                return getLostNodesMap().remove(nodeUrl);
+            }
+        });
+    }
+
+    private boolean containsKeyLostNode(final String nodeUrl) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getLostNodesMap().containsKey(nodeUrl);
+            }
+        });
+    }
+
+    private Collection<RMDeployingNode> valuesLostNodes() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Collection<RMDeployingNode>>() {
+            @Override
+            public Collection<RMDeployingNode> handle() {
+                return getLostNodesMap().values();
+            }
+        });
+    }
+
+    private Map<String, Node> getAcquiredNodesMap() {
+        return (Map<String, Node>) runtimeVariables.get(ACQUIRED_NODES_KEY);
+    }
+
+    private void putAcquiredNode(final String nodeUrl, final Node deployingNode) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getAcquiredNodesMap().put(nodeUrl, deployingNode);
+                return null;
+            }
+        });
+    }
+
+    private void removeAcquiredNode(final String nodeUrl) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getAcquiredNodesMap().remove(nodeUrl);
+                return null;
+            }
+        });
+    }
+
+    private boolean containsKeyAcquiredNode(final String nodeUrl) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getAcquiredNodesMap().containsKey(nodeUrl);
+            }
+        });
+    }
+
+    private boolean getShutdownFlag() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return (Boolean) runtimeVariables.get(SHUTDOWN_FLAG_KEY);
+            }
+        });
+    }
+
+    private void setShutdownFlag(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
+    public boolean isUsingDeployingNode() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return (boolean) runtimeVariables.get(USING_DEPLOYING_NODES_KEY);
+            }
+        });
+    }
+
+    private void setUsingDeployingNodes(final boolean isUsingDeployingNodes) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(USING_DEPLOYING_NODES_KEY, isUsingDeployingNodes);
+                return null;
+            }
+        });
+    }
+
+    protected String getRmUrl() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<String>() {
+            @Override
+            public String handle() {
+                return (String) runtimeVariables.get(RM_URL_KEY);
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LSFInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LSFInfrastructure.java
@@ -68,4 +68,9 @@ public class LSFInfrastructure extends BatchJobInfrastructure {
         return "bsub";
     }
 
+    @Override
+    protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/PBSInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/PBSInfrastructure.java
@@ -86,4 +86,9 @@ public class PBSInfrastructure extends BatchJobInfrastructure {
         logger.debug("no jobID retrieved from submit command output: " + output);
         return null;
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
+    }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
@@ -104,8 +104,6 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
     @Configurable(description = "Linux, Cygwin or Windows depending on\nthe operating system of the remote hosts")
     protected String targetOs = "Linux";
 
-    protected OperatingSystem targetOSObj = null;
-
     /**
      * Additional java options to append to the command executed on the remote
      * host
@@ -119,12 +117,12 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
     @Configurable(credential = true, description = "Absolute path of the credential file")
     protected File rmCredentialsPath;
 
-    protected Credentials credentials = null;
+    private static final String CREDENTIALS_KEY = "credentials";
 
-    /**
-     * Shutdown flag
-     */
-    protected boolean shutdown = false;
+    private static final String TARGET_OS_OBJ_KEY = "targetOSObj";
+
+    /** key of the shutdown flag */
+    private static final String SHUTDOWN_FLAG_KEY = "shutdownFlag";
 
     /**
      * Internal node acquisition method
@@ -139,8 +137,8 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
      *             acquisition failed
      */
     protected void startNodeImpl(InetAddress host, int nbNodes, final List<String> depNodeURLs) throws RMException {
-        String fs = this.targetOSObj.fs;
-        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(this.targetOSObj);
+        String fs = getTargetOSObj().fs;
+        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(getTargetOSObj());
         // we take care of spaces in java path
         clb.setJavaPath(this.javaPath);
         // we set the rm.home prop
@@ -201,7 +199,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
         // finally, the credential's value
         String credString = null;
         try {
-            credString = new String(this.credentials.getBase64());
+            credString = new String(getCredentials().getBase64());
         } catch (KeyException e1) {
             throw new RMException("Could not get base64 credentials", e1);
         }
@@ -325,8 +323,8 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
             this.schedulingPath = parameters[index++].toString();
             // target OS
             if (parameters[index] != null) {
-                this.targetOSObj = OperatingSystem.getOperatingSystem(parameters[index++].toString());
-                if (this.targetOSObj == null) {
+                setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
+                if (getTargetOSObj() == null) {
                     throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
                 }
             } else {
@@ -340,7 +338,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
                 throw new IllegalArgumentException("Credentials must be specified");
             }
             try {
-                this.credentials = Credentials.getCredentialsBase64((byte[]) parameters[index++]);
+                setCredentials(Credentials.getCredentialsBase64((byte[]) parameters[index++]));
             } catch (KeyException e) {
                 throw new IllegalArgumentException("Could not retrieve base64 credentials", e);
             }
@@ -381,6 +379,64 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
 
     @Override
     public void shutDown() {
-        this.shutdown = true;
+        setShutdownFlag(true);
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(CREDENTIALS_KEY, null);
+        runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private Credentials getCredentials() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Credentials>() {
+            @Override
+            public Credentials handle() {
+                return (Credentials) runtimeVariables.get(CREDENTIALS_KEY);
+            }
+        });
+    }
+
+    private void setCredentials(final Credentials credentials) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(CREDENTIALS_KEY, credentials);
+                return null;
+            }
+        });
+    }
+
+    private OperatingSystem getTargetOSObj() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<OperatingSystem>() {
+            @Override
+            public OperatingSystem handle() {
+                return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
+            }
+        });
+    }
+
+    private void setTargetOsObj(final OperatingSystem os) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
+                return null;
+            }
+        });
+    }
+
+    private void setShutdownFlag(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
@@ -104,13 +104,13 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
     @Configurable(description = "Linux, Cygwin or Windows depending on the operating system of the remote hosts")
     protected String targetOs = "Linux";
 
-    protected OperatingSystem targetOSObj;
-
     @Configurable(description = "Options for the java command launching the node on the remote hosts")
     protected String javaOptions;
 
-    /** Shutdown flag */
-    protected volatile boolean shutdown;
+    private static final String TARGET_OS_OBJ_KEY = "targetOSObj";
+
+    /** key of the shutdown flag */
+    private static final String SHUTDOWN_FLAG_KEY = "shutdownFlag";
 
     /**
      * Internal node acquisition method
@@ -126,7 +126,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
      */
     public void startNodeImpl(final InetAddress host, final int nbNodes, final List<String> depNodeURLs)
             throws RMException {
-        String fs = this.targetOSObj.fs;
+        String fs = getTargetOSObj().fs;
         // we set the java security policy file
         ArrayList<String> sb = new ArrayList<>();
         final boolean containsSpace = schedulingPath.contains(" ");
@@ -169,7 +169,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
         if (this.javaOptions != null && !this.javaOptions.trim().isEmpty()) {
             sb.add(this.javaOptions.trim());
         }
-        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(this.targetOSObj);
+        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(getTargetOSObj());
         clb.setJavaPath(this.javaPath);
         clb.setRmHome(this.schedulingPath);
         clb.setPaProperties(sb);
@@ -252,7 +252,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
             Future<Void> deployResult = deployService.submit(new Callable<Void>() {
                 @Override
                 public Void call() throws Exception {
-                    while (!shutdown && !checkAllNodesAreAcquiredAndDo(createdNodeNames, null, null)) {
+                    while (!getShutdownFlag() && !checkAllNodesAreAcquiredAndDo(createdNodeNames, null, null)) {
                         if (anyTimedOut(depNodeURLs)) {
                             throw new IllegalStateException("The upper infrastructure has issued a timeout");
                         }
@@ -367,12 +367,15 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
         if (parameters[index] == null) {
             throw new IllegalArgumentException("Target OS parameter cannot be null");
         }
-        this.targetOSObj = OperatingSystem.getOperatingSystem(parameters[index++].toString());
-        if (this.targetOSObj == null) {
+        setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
+        if (getTargetOSObj() == null) {
             throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
         }
 
         this.javaOptions = parameters[index++].toString();
+
+        // shutdown flag
+        setShutdownFlag(false);
     }
 
     @Override
@@ -406,6 +409,53 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
 
     @Override
     public void shutDown() {
-        this.shutdown = true;
+        setShutdownFlag(true);
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private OperatingSystem getTargetOSObj() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<OperatingSystem>() {
+            @Override
+            public OperatingSystem handle() {
+                return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
+            }
+        });
+    }
+
+    private void setTargetOsObj(final OperatingSystem os) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
+                return null;
+            }
+        });
+    }
+
+    private boolean getShutdownFlag() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return (boolean) runtimeVariables.get(SHUTDOWN_FLAG_KEY);
+            }
+        });
+    }
+
+    private void setShutdownFlag(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/db/NodeSourcesTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/db/NodeSourcesTest.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.resourcemanager.db;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hibernate.cfg.Configuration;
 import org.junit.After;
@@ -43,13 +46,22 @@ import org.ow2.tests.ProActiveTest;
 
 public class NodeSourcesTest extends ProActiveTest {
 
+    // Arbitrary values used for the test
+    private static final String INFRASTRUCTURE_VARIABLE_KEY = "key";
+
+    private static final String INFRASTRUCTURE_VARIABLE_VALUE = "value";
+
     protected static RMDBManager dbManager;
+
+    private Map<String, Object> infrastructureVariables;
 
     @Before
     public void setUp() throws Exception {
         PAResourceManagerProperties.RM_ALIVE_EVENT_FREQUENCY.updateProperty("100");
         Configuration config = new Configuration().configure("/functionaltests/config/hibernate.cfg.xml");
         dbManager = new RMDBManager(config, true, true);
+        infrastructureVariables = new HashMap<>();
+        infrastructureVariables.put(INFRASTRUCTURE_VARIABLE_KEY, INFRASTRUCTURE_VARIABLE_VALUE);
     }
 
     @After
@@ -72,6 +84,7 @@ public class NodeSourcesTest extends ProActiveTest {
     @Test
     public void addNodeSource() throws Exception {
         NodeSourceData nodeSourceData = createNodeSource();
+        nodeSourceData.setInfrastructureVariables(infrastructureVariables);
 
         assertThat(dbManager.getNodeSources()).isEmpty();
 
@@ -86,6 +99,9 @@ public class NodeSourcesTest extends ProActiveTest {
         Assert.assertEquals("infrastructure", nodeSource.getInfrastructureParameters()[0]);
         Assert.assertEquals(StaticPolicy.class.getName(), nodeSource.getPolicyType());
         Assert.assertEquals("policy", nodeSource.getPolicyParameters()[0]);
+        assertThat(nodeSource.getInfrastructureVariables()).hasSize(1);
+        Assert.assertEquals(INFRASTRUCTURE_VARIABLE_VALUE,
+                            nodeSource.getInfrastructureVariables().get(INFRASTRUCTURE_VARIABLE_KEY));
     }
 
     @Test
@@ -97,6 +113,58 @@ public class NodeSourcesTest extends ProActiveTest {
         dbManager.removeNodeSource("ns1");
 
         assertThat(dbManager.getNodeSources()).isEmpty();
+    }
+
+    @Test
+    public void testAddNodeSourceWithEmptyInfrastructureVariables() {
+        NodeSourceData nodeSourceData = createNodeSource();
+        nodeSourceData.setInfrastructureVariables(new HashMap<String, Object>());
+        dbManager.addNodeSource(nodeSourceData);
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        assertThat(nodeSource.getInfrastructureVariables()).hasSize(0);
+    }
+
+    @Test
+    public void testAddNodeSourceWithNullInfrastructureVariables() {
+        dbManager.addNodeSource(createNodeSource());
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        assertThat(nodeSource.getInfrastructureVariables()).isNull();
+    }
+
+    @Test
+    public void testAddNodeSourceWithVariousObjectsInInfrastructureVariables() {
+        NodeSourceData nodeSourceData = createNodeSource();
+        Map<String, Object> infrastructureVariables = new HashMap<>();
+
+        Integer integer = new Integer(42);
+        AtomicBoolean atomicBoolean = new AtomicBoolean(true);
+        char c = 'z';
+        infrastructureVariables.put("anInteger", integer);
+        infrastructureVariables.put("aBoolean", atomicBoolean);
+        infrastructureVariables.put("aChar", c);
+
+        nodeSourceData.setInfrastructureVariables(infrastructureVariables);
+        dbManager.addNodeSource(nodeSourceData);
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        Map<String, Object> retrievedInfravariables = nodeSource.getInfrastructureVariables();
+        assertThat(retrievedInfravariables).hasSize(3);
+        assertThat(retrievedInfravariables.get("anInteger")).isEqualTo(integer);
+        // works with autoboxing
+        assertThat(retrievedInfravariables.get("anInteger")).isEqualTo(42);
+        assertThat(((AtomicBoolean) retrievedInfravariables.get("aBoolean")).get()).isEqualTo(atomicBoolean.get());
+        assertThat(retrievedInfravariables.get("aChar")).isEqualTo(c);
     }
 
     private NodeSourceData createNodeSource() {

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
@@ -28,11 +28,13 @@ package org.ow2.proactive.resourcemanager.nodesource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.security.Permission;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,6 +76,7 @@ public class NodeSourceTest {
         PAResourceManagerProperties.RM_TOPOLOGY_ENABLED.updateProperty("false");
 
         infrastructureManager = mock(InfrastructureManager.class);
+        when(infrastructureManager.isUsingDeployingNode()).thenReturn(false);
 
         NodeSourcePolicy nodeSourcePolicy = mock(NodeSourcePolicy.class);
 


### PR DESCRIPTION
- add column holding infrastructure runtime variable map
- refactor all infrastructures such that their runtime variables are not stored and updated in the map
- persist the update of runtime variables for all infrastructures
- add unit tests