### PR TITLE
Nodes Recovery: add infrastructure info to DB

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1187,11 +1187,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             throw new RuntimeException("Cannot create node source " + data.getName(), e);
         }
 
-        // Infrastructure has been configured and linked to the node source, so we can now persist the runtime
-        // variables of the infrastructure for the first time (they have been initialized during the creation of the
-        // infrastructure, in its configuration.
-        im.persistInfrastructureVariables();
-
         // Adding access to the core for node source and policy.
         // In order to do it node source and policy active objects are added to the clients list.
         // They will be removed from this list when node source is unregistered.
@@ -1697,7 +1692,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             //remove down nodes handled by the source
             //because node source doesn't know anymore its down nodes
             removeAllNodes(sourceName, preempt);
-            nodeSource.shutdown(caller);
+            // here we need the shutdown to be completed before the node source is removed from the database
+            // so we must ensure that the next call is blocking
+            PAFuture.waitFor(nodeSource.shutdown(caller));
             dbManager.removeNodeSource(sourceName);
 
             return new BooleanWrapper(true);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1187,6 +1187,11 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             throw new RuntimeException("Cannot create node source " + data.getName(), e);
         }
 
+        // Infrastructure has been configured and linked to the node source, so we can now persist the runtime
+        // variables of the infrastructure for the first time (they have been initialized during the creation of the
+        // infrastructure, in its configuration.
+        im.persistInfrastructureVariables();
+
         // Adding access to the core for node source and policy.
         // In order to do it node source and policy active objects are added to the clients list.
         // They will be removed from this list when node source is unregistered.

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.db;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.persistence.Column;
@@ -79,6 +80,7 @@ public class NodeSourceData implements Serializable {
         this.policyType = policyType;
         this.policyParameters = policyParameters;
         this.provider = provider;
+        this.infrastructureVariables = new HashMap<>();
     }
 
     @Id

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.db;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -33,12 +34,12 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import javax.security.auth.Subject;
 
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.hibernate.type.SerializableToBlobType;
 import org.ow2.proactive.resourcemanager.authentication.Client;
+import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 
 
 @Entity
@@ -60,6 +61,11 @@ public class NodeSourceData implements Serializable {
     private Object[] policyParameters;
 
     private Client provider;
+
+    /**
+     * name of the variable --> value of the variable
+     */
+    private Map<String, Object> infrastructureVariables;
 
     public NodeSourceData() {
     }
@@ -132,4 +138,15 @@ public class NodeSourceData implements Serializable {
     public void setProvider(Client provider) {
         this.provider = provider;
     }
+
+    @Column(length = Integer.MAX_VALUE)
+    @Type(type = "org.hibernate.type.SerializableToBlobType", parameters = @Parameter(name = SerializableToBlobType.CLASS_NAME, value = "java.lang.Object"))
+    public Map<String, Object> getInfrastructureVariables() {
+        return infrastructureVariables;
+    }
+
+    public void setInfrastructureVariables(Map<String, Object> infrastructureVariables) {
+        this.infrastructureVariables = infrastructureVariables;
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
@@ -298,14 +298,34 @@ public class RMDBManager {
     }
 
     public NodeSourceData getNodeSource(final String sourceName) {
-        return executeReadTransaction(new SessionWork<NodeSourceData>() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public NodeSourceData doInTransaction(Session session) {
-                Query query = session.getNamedQuery("getNodeSourceDataByName").setParameter("name", sourceName);
-                return (NodeSourceData) query.uniqueResult();
-            }
-        });
+        try {
+            return executeReadTransaction(new SessionWork<NodeSourceData>() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public NodeSourceData doInTransaction(Session session) {
+                    Query query = session.getNamedQuery("getNodeSourceDataByName").setParameter("name", sourceName);
+                    return (NodeSourceData) query.uniqueResult();
+                }
+            });
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Exception occured while getting a node source from name '" + sourceName + "'");
+        }
+    }
+
+    public boolean updateNodeSource(final NodeSourceData nodeSourceData) {
+        try {
+            return executeReadWriteTransaction(new SessionWork<Boolean>() {
+                @Override
+                public Boolean doInTransaction(Session session) {
+                    logger.info("Updating a node source " + nodeSourceData.getName() + " in database");
+                    session.update(nodeSourceData);
+                    return true;
+                }
+            });
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Exception occured while updating a node source '" + nodeSourceData.getName() +
+                                       "'");
+        }
     }
 
     public void removeNodeSource(final String sourceName) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -223,6 +223,10 @@ public class NodeSource implements InitActive, RunActive {
 
         stub = (NodeSource) PAActiveObject.getStubOnThis();
         infrastructureManager.setNodeSource(this);
+        // Infrastructure has been configured and linked to the node source, so we can now persist the runtime
+        // variables of the infrastructure for the first time (they have been initialized during the creation of the
+        // infrastructure, in its configuration.
+        infrastructureManager.persistInfrastructureVariables();
         nodeSourcePolicy.setNodeSource((NodeSource) PAActiveObject.getStubOnThis());
 
         Thread.currentThread().setName("Node Source \"" + name + "\"");
@@ -541,13 +545,14 @@ public class NodeSource implements InitActive, RunActive {
     /**
      * Shutdowns the node source and releases all its nodes.
      */
-    public void shutdown(Client initiator) {
+    public BooleanWrapper shutdown(Client initiator) {
         logger.info("[" + name + "] is shutting down by " + initiator);
         toShutdown = true;
 
         if (nodes.size() == 0) {
             shutdownNodeSourceServices(initiator);
         }
+        return new BooleanWrapper(true);
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
@@ -35,8 +35,8 @@ import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.KeyException;
-import java.util.Hashtable;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.node.Node;
@@ -150,29 +150,30 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
     protected String submitJobOpt;
 
     /**
-     * Shutdown flag
+     * Key to retrieve the shutdown flag
      */
-    protected boolean shutdown = false;
+    private static final String SHUTDOWN_FLAG_KEY = "shutdown";
 
     /**
-     * Credentials used by remote nodes to register to the NS
+     * Key to retrieve th credentials used by remote nodes to register to the NS
      */
-    private Credentials credentials = null;
+    private static final String CREDENTIALS_KEY = "credentials";
 
     /**
-     * Nodes currently up and running, nodeName -&gt; jobID
+     * Key to retrieve the map of the nodes currently up and running, nodeName -&gt; jobID
+     * This key is also used as a lock object when the map is accessed.
      */
-    private final Hashtable<String, String> currentNodes = new Hashtable<>();
+    private static final String CURRENT_NODES_KEY = "currentNodes";
 
     /**
-     * The number of pending nodes
+     * Key to retrieve the number of pending nodes
      */
-    private volatile Integer deployingNodes = 0;
+    private static final String DEPLOYING_NODES_KEY = "deployingNodes";
 
     /**
-     * To notify the control loop of the pending node timeout
+     * Key to retrieve the map that is used to notify the control loop of the pending node timeout
      */
-    private ConcurrentHashMap<String, Boolean> pnTimeout = new ConcurrentHashMap<>();
+    private static final String PN_TIMEOUT_KEY = "pnTimeout";
 
     /**
      * Acquires as much nodes as possible, making one distinct reservation per
@@ -180,11 +181,9 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
      */
     @Override
     public void acquireAllNodes() {
-        synchronized (currentNodes) {
-            // deployingNodes and currentNodes updated in acquireNode
-            for (; (currentNodes.size() + deployingNodes) < maxNodes;) {
-                acquireNode();
-            }
+        // deployingNodes and currentNodes updated in acquireNode
+        for (; (getCurrentNodesSize() + getNbDeployingNodes()) < maxNodes;) {
+            acquireNode();
         }
     }
 
@@ -194,16 +193,22 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
     @Override
     public void acquireNode() {
         final String bjs = getBatchinJobSystemName();
-        synchronized (currentNodes) {
-            int currentNodesSize = currentNodes.size();
-            if ((currentNodesSize + deployingNodes) >= maxNodes) {
+        writeLock.lock();
+        try {
+            int currentNodesSize = getCurrentNodesSize();
+            if ((currentNodesSize + getNbDeployingNodes()) >= maxNodes) {
                 logger.warn("Attempting to acquire nodes while maximum reached");
                 return;
             } else {
-                deployingNodes++;
+                incrementDeployingNodes();
             }
             logger.debug("Acquiring a new " + bjs + " node. # of current nodes: " + currentNodesSize +
-                         " - # of deploying nodes: " + deployingNodes);
+                         " - # of deploying nodes: " + getNbDeployingNodes());
+        } catch (RuntimeException e) {
+            logger.error("Exception while acquiring a node: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
 
         // new thread: call will block until registration of the node to the RM
@@ -212,17 +217,17 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
                 try {
                     // currentNodes & deployingNodes are updated in startNode
                     startNode();
-                    logger.debug("new " + bjs + " Node acquired. # of current nodes: " + currentNodes.size() +
-                                 " - # of deploying nodes: " + deployingNodes);
+                    logger.debug("new " + bjs + " Node acquired. # of current nodes: " + getCurrentNodesSize() +
+                                 " - # of deploying nodes: " + getNbDeployingNodes());
                     return;
                 } catch (Exception e) {
                     logger.error("Could not acquire node ", e);
                 }
                 // deployment failed, one "deployingNodes" (volatile) not
                 // expected anymore...
-                deployingNodes--;
+                decrementDeployingNodes();
                 logger.debug("# of deploying nodes arranged given the last checked exception. # of current nodes: " +
-                             currentNodes.size() + " - # of deploying nodes: " + deployingNodes);
+                             getCurrentNodesSize() + " - # of deploying nodes: " + getNbDeployingNodes());
             }
         });
     }
@@ -244,12 +249,12 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
         String nodeName = getBatchinJobSystemName() + "-" + nodeSource.getName() + "-" + ProActiveCounter.getUniqID();
         clb.setNodeName(nodeName);
         clb.setJavaPath(this.javaPath);
-        clb.setRmURL(this.rmUrl);
+        clb.setRmURL(getRmUrl());
         clb.setRmHome(this.schedulingPath);
         clb.setSourceName(this.nodeSource.getName());
         clb.setPaProperties(this.javaOptions);
         try {
-            clb.setCredentialsValueAndNullOthers(new String(this.credentials.getBase64()));
+            clb.setCredentialsValueAndNullOthers(new String(getCredentials().getBase64()));
         } catch (KeyException e) {
             this.handleFailedDeployment(clb, e);
         }
@@ -279,7 +284,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
                                                     obfuscatedCmd,
                                                     "Deploying node on " + getBatchinJobSystemName() + " scheduler",
                                                     this.nodeTimeOut);
-        this.pnTimeout.put(dnURL, new Boolean(false));
+        putPnTimeout(dnURL, Boolean.FALSE);
 
         // executing the command
         Process p;
@@ -311,7 +316,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
                                      // Tries to wait for this node
                                      // registration...
         int circuitBreakerThreshold = 5;
-        while (!this.pnTimeout.get(dnURL) && circuitBreakerThreshold > 0) {
+        while (!getPnTimeout(dnURL) && circuitBreakerThreshold > 0) {
             try {
                 int exitCode = p.exitValue();
                 if (exitCode != 0 && !isJobIDValid) {
@@ -365,15 +370,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
           // threshold reached
 
         // the node is not expected anymore
-        if (pnTimeout.get(dnURL)) {
-            // we remove it
-            this.pnTimeout.remove(dnURL);
-            // removes the job
-            this.deleteJob(this.extractSubmitOutput(id));
-            // we destroy the process
-            p.destroy();
-            throw new RMException("Deploying Node " + nodeName + " not expected any more");
-        }
+        atomicRemovePnTimeoutAndJob(nodeName, dnURL, p, id);
 
         if (circuitBreakerThreshold <= 0) {
             logger.error("Circuit breaker threshold reached while monitoring ssh subprocess.");
@@ -496,7 +493,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
                 throw new IllegalArgumentException("Credentials must be specified");
             }
             try {
-                this.credentials = Credentials.getCredentialsBase64((byte[]) parameters[index++]);
+                setCredentials(Credentials.getCredentialsBase64((byte[]) parameters[index++]));
             } catch (KeyException e) {
                 throw new IllegalArgumentException("Could not retrieve base64 credentials", e);
             }
@@ -562,7 +559,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
      */
     @Override
     protected void notifyDeployingNodeLost(String pnURL) {
-        this.pnTimeout.put(pnURL, true);
+        putPnTimeout(pnURL, true);
     }
 
     /**
@@ -573,7 +570,7 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
         String deleteCmd = getDeleteJobCommand();
         String jobID = null;
         String nodeName = node.getNodeInformation().getName();
-        if ((jobID = currentNodes.get(nodeName)) != null) {
+        if ((jobID = getCurrentNode(nodeName)) != null) {
             try {
                 deleteJob(jobID);
             } catch (RMException e) {
@@ -582,10 +579,16 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
             }
             // atomic remove is important, furthermore we ensure consistent
             // trace
-            synchronized (currentNodes) {
-                currentNodes.remove(nodeName);
-                logger.debug("Node " + nodeName + " removed. # of current nodes: " + currentNodes.size() +
-                             " # of deploying nodes: " + deployingNodes);
+            writeLock.lock();
+            try {
+                removeCurrentNode(nodeName);
+                logger.debug("Node " + nodeName + " removed. # of current nodes: " + getCurrentNodesSize() +
+                             " # of deploying nodes: " + getNbDeployingNodes());
+            } catch (RuntimeException e) {
+                logger.error("Exception while removing a node: " + e.getMessage());
+                throw e;
+            } finally {
+                writeLock.unlock();
             }
         } else {
             logger.error("Node " + nodeName + " is not known as a Node belonging to this " +
@@ -664,21 +667,27 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
 
     @Override
     public void shutDown() {
-        shutdown = true;
+        setShutdown(true);
     }
 
     /**
      * Adds the given node's name and its associated jobID to the
-     * {@link #currentNodes} hashtable and decrements the number of deploying
+     * current node map and decrements the number of deploying
      * nodes.
      * 
      * @param nodeName
      * @param id
      */
     private void addNodeAndDecrementDeployingNode(String nodeName, String id) {
-        synchronized (currentNodes) {
-            currentNodes.put(nodeName, id);
-            deployingNodes--;
+        writeLock.lock();
+        try {
+            putCurrentNode(nodeName, id);
+            decrementDeployingNodes();
+        } catch (RuntimeException e) {
+            logger.error("Exception while moving a node from deploying to current: " + e.getMessage());
+            throw e;
+        } finally {
+            writeLock.unlock();
         }
     }
 
@@ -778,5 +787,165 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
      *         method is unable to compute the job's ID.
      */
     protected abstract String extractSubmitOutput(String output);
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+        runtimeVariables.put(CREDENTIALS_KEY, null);
+        runtimeVariables.put(CURRENT_NODES_KEY, new HashMap<String, String>());
+        runtimeVariables.put(DEPLOYING_NODES_KEY, 0);
+        runtimeVariables.put(PN_TIMEOUT_KEY, new HashMap<String, Boolean>());
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private void setShutdown(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
+    private Credentials getCredentials() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Credentials>() {
+            @Override
+            public Credentials handle() {
+                return (Credentials) runtimeVariables.get(CREDENTIALS_KEY);
+            }
+        });
+    }
+
+    private void setCredentials(final Credentials credentials) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(CREDENTIALS_KEY, credentials);
+                return null;
+            }
+        });
+    }
+
+    private void incrementDeployingNodes() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(DEPLOYING_NODES_KEY) + 1;
+                runtimeVariables.put(DEPLOYING_NODES_KEY, updated);
+                return null;
+            }
+        });
+    }
+
+    private void decrementDeployingNodes() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(DEPLOYING_NODES_KEY) - 1;
+                runtimeVariables.put(DEPLOYING_NODES_KEY, updated);
+                return null;
+            }
+        });
+    }
+
+    private int getNbDeployingNodes() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return (int) runtimeVariables.get(DEPLOYING_NODES_KEY);
+            }
+        });
+    }
+
+    private Map<String, String> getCurrentNodes() {
+        return (Map<String, String>) runtimeVariables.get(CURRENT_NODES_KEY);
+    }
+
+    private String getCurrentNode(final String key) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<String>() {
+            @Override
+            public String handle() {
+                return getCurrentNodes().get(key);
+            }
+        });
+    }
+
+    private int getCurrentNodesSize() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Integer>() {
+            @Override
+            public Integer handle() {
+                return getCurrentNodes().size();
+            }
+        });
+    }
+
+    private void putCurrentNode(final String key, final String value) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getCurrentNodes().put(key, value);
+                return null;
+            }
+        });
+    }
+
+    private void removeCurrentNode(final String key) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getCurrentNodes().remove(key);
+                return null;
+            }
+        });
+    }
+
+    private Map<String, Boolean> getPnTimeoutMap() {
+        return (Map<String, Boolean>) runtimeVariables.get(PN_TIMEOUT_KEY);
+    }
+
+    private Boolean getPnTimeout(final String key) {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return getPnTimeoutMap().get(key);
+            }
+        });
+    }
+
+    private void putPnTimeout(final String key, final Boolean value) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                getPnTimeoutMap().put(key, value);
+                return null;
+            }
+        });
+    }
+
+    private void atomicRemovePnTimeoutAndJob(final String nodeName, final String dnURL, final Process p, final String id)
+            throws RMException {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                if (getPnTimeout(dnURL)) {
+                    // we remove the pn timeout
+                    getPnTimeoutMap().remove(dnURL);
+                    try {
+                        // we remove the job
+                        deleteJob(extractSubmitOutput(id));
+                        // we destroy the process
+                        p.destroy();
+                    } catch (RMException e) {
+                        logger.error(e);
+                    } finally {
+                        logger.error("Deploying Node " + nodeName + " not expected any more");
+                    }
+                }
+                return null;
+            }
+        });
+    }
 
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
@@ -924,8 +924,8 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
         });
     }
 
-    private void atomicRemovePnTimeoutAndJob(final String nodeName, final String dnURL, final Process p, final String id)
-            throws RMException {
+    private void atomicRemovePnTimeoutAndJob(final String nodeName, final String dnURL, final Process p,
+            final String id) throws RMException {
         setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
             @Override
             public Void handle() {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/DefaultInfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/DefaultInfrastructureManager.java
@@ -46,7 +46,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
     protected static Logger logger = Logger.getLogger(DefaultInfrastructureManager.class);
 
     /** registered nodes number */
-    protected int nodesCount = 0;
+    private static final String NODES_COUNT_KEY = "nodesCount";
 
     /**
      * Proactive default constructor.
@@ -99,7 +99,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
                     }
                 });
             }
-            nodesCount--;
+            decrementNodesCount();
         } catch (Exception e) {
             throw new RMException(e);
         }
@@ -149,7 +149,7 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
      */
     @Override
     public void notifyAcquiredNode(Node node) throws RMException {
-        nodesCount++;
+        incrementNodesCount();
     }
 
     /**
@@ -166,6 +166,35 @@ public class DefaultInfrastructureManager extends InfrastructureManager {
      */
     @Override
     public void shutDown() {
+    }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(NODES_COUNT_KEY, 0);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private void incrementNodesCount() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(NODES_COUNT_KEY) + 1;
+                runtimeVariables.put(NODES_COUNT_KEY, updated);
+                return null;
+            }
+        });
+    }
+
+    private void decrementNodesCount() {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                int updated = (int) runtimeVariables.get(NODES_COUNT_KEY) - 1;
+                runtimeVariables.put(NODES_COUNT_KEY, updated);
+                return null;
+            }
+        });
     }
 
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LSFInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LSFInfrastructure.java
@@ -68,4 +68,9 @@ public class LSFInfrastructure extends BatchJobInfrastructure {
         return "bsub";
     }
 
+    @Override
+    protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/PBSInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/PBSInfrastructure.java
@@ -86,4 +86,9 @@ public class PBSInfrastructure extends BatchJobInfrastructure {
         logger.debug("no jobID retrieved from submit command output: " + output);
         return null;
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
+    }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
@@ -104,8 +104,6 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
     @Configurable(description = "Linux, Cygwin or Windows depending on\nthe operating system of the remote hosts")
     protected String targetOs = "Linux";
 
-    protected OperatingSystem targetOSObj = null;
-
     /**
      * Additional java options to append to the command executed on the remote
      * host
@@ -119,12 +117,12 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
     @Configurable(credential = true, description = "Absolute path of the credential file")
     protected File rmCredentialsPath;
 
-    protected Credentials credentials = null;
+    private static final String CREDENTIALS_KEY = "credentials";
 
-    /**
-     * Shutdown flag
-     */
-    protected boolean shutdown = false;
+    private static final String TARGET_OS_OBJ_KEY = "targetOSObj";
+
+    /** key of the shutdown flag */
+    private static final String SHUTDOWN_FLAG_KEY = "shutdownFlag";
 
     /**
      * Internal node acquisition method
@@ -139,8 +137,8 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
      *             acquisition failed
      */
     protected void startNodeImpl(InetAddress host, int nbNodes, final List<String> depNodeURLs) throws RMException {
-        String fs = this.targetOSObj.fs;
-        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(this.targetOSObj);
+        String fs = getTargetOSObj().fs;
+        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(getTargetOSObj());
         // we take care of spaces in java path
         clb.setJavaPath(this.javaPath);
         // we set the rm.home prop
@@ -201,7 +199,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
         // finally, the credential's value
         String credString = null;
         try {
-            credString = new String(this.credentials.getBase64());
+            credString = new String(getCredentials().getBase64());
         } catch (KeyException e1) {
             throw new RMException("Could not get base64 credentials", e1);
         }
@@ -325,8 +323,8 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
             this.schedulingPath = parameters[index++].toString();
             // target OS
             if (parameters[index] != null) {
-                this.targetOSObj = OperatingSystem.getOperatingSystem(parameters[index++].toString());
-                if (this.targetOSObj == null) {
+                setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
+                if (getTargetOSObj() == null) {
                     throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
                 }
             } else {
@@ -340,7 +338,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
                 throw new IllegalArgumentException("Credentials must be specified");
             }
             try {
-                this.credentials = Credentials.getCredentialsBase64((byte[]) parameters[index++]);
+                setCredentials(Credentials.getCredentialsBase64((byte[]) parameters[index++]));
             } catch (KeyException e) {
                 throw new IllegalArgumentException("Could not retrieve base64 credentials", e);
             }
@@ -381,6 +379,64 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
 
     @Override
     public void shutDown() {
-        this.shutdown = true;
+        setShutdownFlag(true);
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(CREDENTIALS_KEY, null);
+        runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private Credentials getCredentials() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Credentials>() {
+            @Override
+            public Credentials handle() {
+                return (Credentials) runtimeVariables.get(CREDENTIALS_KEY);
+            }
+        });
+    }
+
+    private void setCredentials(final Credentials credentials) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(CREDENTIALS_KEY, credentials);
+                return null;
+            }
+        });
+    }
+
+    private OperatingSystem getTargetOSObj() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<OperatingSystem>() {
+            @Override
+            public OperatingSystem handle() {
+                return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
+            }
+        });
+    }
+
+    private void setTargetOsObj(final OperatingSystem os) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
+                return null;
+            }
+        });
+    }
+
+    private void setShutdownFlag(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructure.java
@@ -323,10 +323,11 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
             this.schedulingPath = parameters[index++].toString();
             // target OS
             if (parameters[index] != null) {
-                setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
-                if (getTargetOSObj() == null) {
+                OperatingSystem targetOs = OperatingSystem.getOperatingSystem(parameters[index++].toString());
+                if (targetOs == null) {
                     throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
                 }
+                runtimeVariables.put(TARGET_OS_OBJ_KEY, targetOs);
             } else {
                 throw new IllegalArgumentException("Target OS parameter cannot be null");
             }
@@ -338,7 +339,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
                 throw new IllegalArgumentException("Credentials must be specified");
             }
             try {
-                setCredentials(Credentials.getCredentialsBase64((byte[]) parameters[index++]));
+                runtimeVariables.put(CREDENTIALS_KEY, Credentials.getCredentialsBase64((byte[]) parameters[index++]));
             } catch (KeyException e) {
                 throw new IllegalArgumentException("Could not retrieve base64 credentials", e);
             }
@@ -384,6 +385,7 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
 
     @Override
     protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
         runtimeVariables.put(CREDENTIALS_KEY, null);
         runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
         runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
@@ -400,31 +402,11 @@ public class SSHInfrastructure extends HostsFileBasedInfrastructureManager {
         });
     }
 
-    private void setCredentials(final Credentials credentials) {
-        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
-            @Override
-            public Void handle() {
-                runtimeVariables.put(CREDENTIALS_KEY, credentials);
-                return null;
-            }
-        });
-    }
-
     private OperatingSystem getTargetOSObj() {
         return getRuntimeVariable(new RuntimeVariablesHandler<OperatingSystem>() {
             @Override
             public OperatingSystem handle() {
                 return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
-            }
-        });
-    }
-
-    private void setTargetOsObj(final OperatingSystem os) {
-        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
-            @Override
-            public Void handle() {
-                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
-                return null;
             }
         });
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
@@ -104,13 +104,13 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
     @Configurable(description = "Linux, Cygwin or Windows depending on the operating system of the remote hosts")
     protected String targetOs = "Linux";
 
-    protected OperatingSystem targetOSObj;
-
     @Configurable(description = "Options for the java command launching the node on the remote hosts")
     protected String javaOptions;
 
-    /** Shutdown flag */
-    protected volatile boolean shutdown;
+    private static final String TARGET_OS_OBJ_KEY = "targetOSObj";
+
+    /** key of the shutdown flag */
+    private static final String SHUTDOWN_FLAG_KEY = "shutdownFlag";
 
     /**
      * Internal node acquisition method
@@ -126,7 +126,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
      */
     public void startNodeImpl(final InetAddress host, final int nbNodes, final List<String> depNodeURLs)
             throws RMException {
-        String fs = this.targetOSObj.fs;
+        String fs = getTargetOSObj().fs;
         // we set the java security policy file
         ArrayList<String> sb = new ArrayList<>();
         final boolean containsSpace = schedulingPath.contains(" ");
@@ -169,7 +169,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
         if (this.javaOptions != null && !this.javaOptions.trim().isEmpty()) {
             sb.add(this.javaOptions.trim());
         }
-        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(this.targetOSObj);
+        CommandLineBuilder clb = super.getDefaultCommandLineBuilder(getTargetOSObj());
         clb.setJavaPath(this.javaPath);
         clb.setRmHome(this.schedulingPath);
         clb.setPaProperties(sb);
@@ -252,7 +252,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
             Future<Void> deployResult = deployService.submit(new Callable<Void>() {
                 @Override
                 public Void call() throws Exception {
-                    while (!shutdown && !checkAllNodesAreAcquiredAndDo(createdNodeNames, null, null)) {
+                    while (!getShutdownFlag() && !checkAllNodesAreAcquiredAndDo(createdNodeNames, null, null)) {
                         if (anyTimedOut(depNodeURLs)) {
                             throw new IllegalStateException("The upper infrastructure has issued a timeout");
                         }
@@ -367,12 +367,15 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
         if (parameters[index] == null) {
             throw new IllegalArgumentException("Target OS parameter cannot be null");
         }
-        this.targetOSObj = OperatingSystem.getOperatingSystem(parameters[index++].toString());
-        if (this.targetOSObj == null) {
+        setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
+        if (getTargetOSObj() == null) {
             throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
         }
 
         this.javaOptions = parameters[index++].toString();
+
+        // shutdown flag
+        setShutdownFlag(false);
     }
 
     @Override
@@ -406,6 +409,53 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
 
     @Override
     public void shutDown() {
-        this.shutdown = true;
+        setShutdownFlag(true);
     }
+
+    @Override
+    protected void initializeRuntimeVariables() {
+        runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
+        runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
+    }
+
+    // Below are wrapper methods around the runtime variables map
+
+    private OperatingSystem getTargetOSObj() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<OperatingSystem>() {
+            @Override
+            public OperatingSystem handle() {
+                return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
+            }
+        });
+    }
+
+    private void setTargetOsObj(final OperatingSystem os) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
+                return null;
+            }
+        });
+    }
+
+    private boolean getShutdownFlag() {
+        return getRuntimeVariable(new RuntimeVariablesHandler<Boolean>() {
+            @Override
+            public Boolean handle() {
+                return (boolean) runtimeVariables.get(SHUTDOWN_FLAG_KEY);
+            }
+        });
+    }
+
+    private void setShutdownFlag(final boolean isShutdown) {
+        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
+            @Override
+            public Void handle() {
+                runtimeVariables.put(SHUTDOWN_FLAG_KEY, isShutdown);
+                return null;
+            }
+        });
+    }
+
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/SSHInfrastructureV2.java
@@ -367,15 +367,13 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
         if (parameters[index] == null) {
             throw new IllegalArgumentException("Target OS parameter cannot be null");
         }
-        setTargetOsObj(OperatingSystem.getOperatingSystem(parameters[index++].toString()));
-        if (getTargetOSObj() == null) {
+        OperatingSystem targetOs = OperatingSystem.getOperatingSystem(parameters[index++].toString());
+        if (targetOs == null) {
             throw new IllegalArgumentException("Only 'Linux', 'Windows' and 'Cygwin' are valid values for Target OS Property.");
         }
+        runtimeVariables.put(TARGET_OS_OBJ_KEY, targetOs);
 
         this.javaOptions = parameters[index++].toString();
-
-        // shutdown flag
-        setShutdownFlag(false);
     }
 
     @Override
@@ -414,6 +412,7 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
 
     @Override
     protected void initializeRuntimeVariables() {
+        super.initializeRuntimeVariables();
         runtimeVariables.put(TARGET_OS_OBJ_KEY, null);
         runtimeVariables.put(SHUTDOWN_FLAG_KEY, false);
     }
@@ -425,16 +424,6 @@ public class SSHInfrastructureV2 extends HostsFileBasedInfrastructureManager {
             @Override
             public OperatingSystem handle() {
                 return (OperatingSystem) runtimeVariables.get(TARGET_OS_OBJ_KEY);
-            }
-        });
-    }
-
-    private void setTargetOsObj(final OperatingSystem os) {
-        setRuntimeVariable(new RuntimeVariablesHandler<Void>() {
-            @Override
-            public Void handle() {
-                runtimeVariables.put(TARGET_OS_OBJ_KEY, os);
-                return null;
             }
         });
     }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/db/NodeSourcesTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/db/NodeSourcesTest.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.resourcemanager.db;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hibernate.cfg.Configuration;
 import org.junit.After;
@@ -43,13 +46,22 @@ import org.ow2.tests.ProActiveTest;
 
 public class NodeSourcesTest extends ProActiveTest {
 
+    // Arbitrary values used for the test
+    private static final String INFRASTRUCTURE_VARIABLE_KEY = "key";
+
+    private static final String INFRASTRUCTURE_VARIABLE_VALUE = "value";
+
     protected static RMDBManager dbManager;
+
+    private Map<String, Object> infrastructureVariables;
 
     @Before
     public void setUp() throws Exception {
         PAResourceManagerProperties.RM_ALIVE_EVENT_FREQUENCY.updateProperty("100");
         Configuration config = new Configuration().configure("/functionaltests/config/hibernate.cfg.xml");
         dbManager = new RMDBManager(config, true, true);
+        infrastructureVariables = new HashMap<>();
+        infrastructureVariables.put(INFRASTRUCTURE_VARIABLE_KEY, INFRASTRUCTURE_VARIABLE_VALUE);
     }
 
     @After
@@ -72,6 +84,7 @@ public class NodeSourcesTest extends ProActiveTest {
     @Test
     public void addNodeSource() throws Exception {
         NodeSourceData nodeSourceData = createNodeSource();
+        nodeSourceData.setInfrastructureVariables(infrastructureVariables);
 
         assertThat(dbManager.getNodeSources()).isEmpty();
 
@@ -86,6 +99,9 @@ public class NodeSourcesTest extends ProActiveTest {
         Assert.assertEquals("infrastructure", nodeSource.getInfrastructureParameters()[0]);
         Assert.assertEquals(StaticPolicy.class.getName(), nodeSource.getPolicyType());
         Assert.assertEquals("policy", nodeSource.getPolicyParameters()[0]);
+        assertThat(nodeSource.getInfrastructureVariables()).hasSize(1);
+        Assert.assertEquals(INFRASTRUCTURE_VARIABLE_VALUE,
+                            nodeSource.getInfrastructureVariables().get(INFRASTRUCTURE_VARIABLE_KEY));
     }
 
     @Test
@@ -97,6 +113,58 @@ public class NodeSourcesTest extends ProActiveTest {
         dbManager.removeNodeSource("ns1");
 
         assertThat(dbManager.getNodeSources()).isEmpty();
+    }
+
+    @Test
+    public void testAddNodeSourceWithEmptyInfrastructureVariables() {
+        NodeSourceData nodeSourceData = createNodeSource();
+        nodeSourceData.setInfrastructureVariables(new HashMap<String, Object>());
+        dbManager.addNodeSource(nodeSourceData);
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        assertThat(nodeSource.getInfrastructureVariables()).hasSize(0);
+    }
+
+    @Test
+    public void testAddNodeSourceWithNullInfrastructureVariables() {
+        dbManager.addNodeSource(createNodeSource());
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        assertThat(nodeSource.getInfrastructureVariables()).isNull();
+    }
+
+    @Test
+    public void testAddNodeSourceWithVariousObjectsInInfrastructureVariables() {
+        NodeSourceData nodeSourceData = createNodeSource();
+        Map<String, Object> infrastructureVariables = new HashMap<>();
+
+        Integer integer = new Integer(42);
+        AtomicBoolean atomicBoolean = new AtomicBoolean(true);
+        char c = 'z';
+        infrastructureVariables.put("anInteger", integer);
+        infrastructureVariables.put("aBoolean", atomicBoolean);
+        infrastructureVariables.put("aChar", c);
+
+        nodeSourceData.setInfrastructureVariables(infrastructureVariables);
+        dbManager.addNodeSource(nodeSourceData);
+
+        Collection<NodeSourceData> nodeSources = dbManager.getNodeSources();
+        assertThat(nodeSources).hasSize(1);
+
+        NodeSourceData nodeSource = nodeSources.iterator().next();
+        Map<String, Object> retrievedInfravariables = nodeSource.getInfrastructureVariables();
+        assertThat(retrievedInfravariables).hasSize(3);
+        assertThat(retrievedInfravariables.get("anInteger")).isEqualTo(integer);
+        // works with autoboxing
+        assertThat(retrievedInfravariables.get("anInteger")).isEqualTo(42);
+        assertThat(((AtomicBoolean) retrievedInfravariables.get("aBoolean")).get()).isEqualTo(atomicBoolean.get());
+        assertThat(retrievedInfravariables.get("aChar")).isEqualTo(c);
     }
 
     private NodeSourceData createNodeSource() {

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
@@ -28,11 +28,13 @@ package org.ow2.proactive.resourcemanager.nodesource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.security.Permission;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,6 +76,7 @@ public class NodeSourceTest {
         PAResourceManagerProperties.RM_TOPOLOGY_ENABLED.updateProperty("false");
 
         infrastructureManager = mock(InfrastructureManager.class);
+        when(infrastructureManager.isUsingDeployingNode()).thenReturn(false);
 
         NodeSourcePolicy nodeSourcePolicy = mock(NodeSourcePolicy.class);
 

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerTest.java
@@ -26,8 +26,12 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -208,6 +212,21 @@ public class InfrastructureManagerTest {
         assertThat(infrastructureManager.getDeployingNodesDeployingState()).hasSize(1);
         assertThat(infrastructureManager.getDeployingNodesLostState().get(lostNode.getNodeURL())).isSameAs(lostNode2);
         assertThat(infrastructureManager.getDeployingNodesLostState().get(lostNode2.getNodeURL())).isSameAs(lostNode2);
+    }
+
+    @Test
+    public void testPersistInfrastructureVariables() {
+        infrastructureManager.persistInfrastructureVariables();
+        verify(nodeSourceData, times(1) ).setInfrastructureVariables(anyMap());
+        verify(dbManager, times(1) ).updateNodeSource(eq(nodeSourceData));
+    }
+
+    @Test
+    public void testDoNotPersistInfrastructureVariablesWhenCannotFindNodeSource() {
+        when(dbManager.getNodeSource(anyString())).thenReturn(null);
+        infrastructureManager.persistInfrastructureVariables();
+        verify(nodeSourceData, times(0) ).setInfrastructureVariables(anyMap());
+        verify(dbManager, times(0) ).updateNodeSource(eq(nodeSourceData));
     }
 
     private static final class TestingInfrastructureManager extends InfrastructureManager {


### PR DESCRIPTION
- add column holding infrastructure runtime variable map
- refactor all infrastructures such that their runtime variables are now stored and updated in the map. Infrastructures use now read/write locks to synchronize variable accesses.
- persist the update of runtime variables for all infrastructures
- add and align unit tests